### PR TITLE
Add rouge-dx-ai image variant

### DIFF
--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -1,5 +1,8 @@
 name: Latest Images
 on:
+  push:
+    branches:
+      - main
   merge_group:
   # pull_request:
   #   branches:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         image_flavor: ${{ fromJson(inputs.image_flavors) }}
-        base_name: ["${{ inputs.brand_name }}", "${{ inputs.brand_name }}-dx"]
+        base_name: ["${{ inputs.brand_name }}", "${{ inputs.brand_name }}-dx", "${{ inputs.brand_name }}-dx-ai"]
         stream_name: ["${{ inputs.stream_name }}"]
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Code Instructions
+
+## Git
+
+- Never add a `Co-Authored-By` line to commits.

--- a/Justfile
+++ b/Justfile
@@ -5,6 +5,7 @@ brew_image := "ghcr.io/ublue-os/brew:latest"
 images := '(
     [rouge]=rouge
     [rouge-dx]=rouge-dx
+    [rouge-dx-ai]=rouge-dx-ai
 )'
 flavors := '(
     [main]=main
@@ -173,9 +174,10 @@ build $image="rouge" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipeline=
     # Build Arguments
     BUILD_ARGS=()
     # Target
-    if [[ "${image}" =~ dx ]]; then
+    if [[ "${image}" =~ dx-ai ]]; then
+        BUILD_ARGS+=("--build-arg" "IMAGE_FLAVOR=dx-ai")
+    elif [[ "${image}" =~ dx ]]; then
         BUILD_ARGS+=("--build-arg" "IMAGE_FLAVOR=dx")
-        target="dx"
     fi
     BUILD_ARGS+=("--build-arg" "AKMODS_FLAVOR=${akmods_flavor}")
     BUILD_ARGS+=("--build-arg" "BASE_IMAGE_NAME=${base_image_name}")
@@ -724,6 +726,6 @@ retag-nvidia-on-ghcr working_tag="" stream="" dry_run="1":
         echo "$GITHUB_PAT" | podman login -u $GITHUB_USERNAME --password-stdin ghcr.io
         skopeo="skopeo"
     fi
-    for image in rouge-nvidia-open rouge-dx-nvidia-open; do
+    for image in rouge-nvidia-open rouge-dx-nvidia-open rouge-dx-ai-nvidia-open; do
       $skopeo copy docker://ghcr.io/baqhub/${image}:{{ working_tag }} docker://ghcr.io/baqhub/${image}:{{ stream }}
     done

--- a/build_files/dx-ai/00-dx-ai.sh
+++ b/build_files/dx-ai/00-dx-ai.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/bash
+
+echo "::group:: ===$(basename "$0")==="
+
+set -ouex pipefail
+
+# Add NVIDIA container toolkit repo
+dnf config-manager addrepo --from-repofile=https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo
+sed -i "s/enabled=.*/enabled=0/g" /etc/yum.repos.d/nvidia-container-toolkit.repo
+
+# Install nvidia-container-toolkit
+dnf -y install --enablerepo=nvidia-container-toolkit-experimental \
+    nvidia-container-toolkit
+
+# Enable CDI spec generation on boot
+systemctl enable nvidia-ctk-cdi-generate.service
+
+echo "::endgroup::"

--- a/build_files/shared/build-dx-ai.sh
+++ b/build_files/shared/build-dx-ai.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+set -xeou pipefail
+
+echo "::group:: Copy Files"
+
+# Copy AI-specific system files
+rsync -rvK /ctx/system_files/dx-ai/ /
+
+echo "::endgroup::"
+
+# Install nvidia-container-toolkit
+/ctx/build_files/dx-ai/00-dx-ai.sh

--- a/build_files/shared/build.sh
+++ b/build_files/shared/build.sh
@@ -47,9 +47,14 @@ echo "::endgroup::"
 # Regenerate initramfs
 /ctx/build_files/base/19-initramfs.sh
 
-if [ "${IMAGE_FLAVOR}" == "dx" ] ; then
+if [ "${IMAGE_FLAVOR}" == "dx" ] || [ "${IMAGE_FLAVOR}" == "dx-ai" ]; then
   # Now we build DX!
   /ctx/build_files/shared/build-dx.sh
+fi
+
+if [ "${IMAGE_FLAVOR}" == "dx-ai" ]; then
+  # Now we build DX-AI!
+  /ctx/build_files/shared/build-dx-ai.sh
 fi
 
 # Validate all repos are disabled before committing

--- a/system_files/dx-ai/usr/lib/systemd/system/nvidia-ctk-cdi-generate.service
+++ b/system_files/dx-ai/usr/lib/systemd/system/nvidia-ctk-cdi-generate.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Generate NVIDIA CDI specifications
+After=local-fs.target
+ConditionPathExists=/usr/bin/nvidia-ctk
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Add `rouge-dx-ai` image variant that extends `rouge-dx` with `nvidia-container-toolkit` for running GPU-accelerated AI models in containers
- Add systemd service to generate NVIDIA CDI specs on boot so containers can discover GPUs
- Trigger latest image builds on push to main

## Test plan
- [ ] Build locally: `just build rouge-dx-ai latest nvidia-open`
- [ ] Verify `nvidia-ctk` is installed in the image
- [ ] Verify CDI generation service is enabled
- [ ] Confirm `rouge` and `rouge-dx` builds are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)